### PR TITLE
New operation model types and SendHttpRequest operation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ python_requires = >=3.12
 install_requires =
     pydantic>=2.10.6,<3.0.0
     pandas>=2.2.3,<3.0.0
-    streamlit>=1.42.2,<2.0.0
+    streamlit>=1.46.0,<2.0.0
     streamlit-ace>=0.1.1,<1.0.0
     streamlit-modal>=0.1.2,<1.0.0
     boto3>=1.37.4,<2.0.0

--- a/src/datarush/core/operations/__init__.py
+++ b/src/datarush/core/operations/__init__.py
@@ -9,6 +9,7 @@ from datarush.core.operations.sources import (
     local_file_source,
     s3_dataset_source,
     s3_object_source,
+    send_http_request,
 )
 from datarush.core.operations.transformations import (
     add_range_column,
@@ -69,6 +70,7 @@ def get_operation_type_by_name(name: str) -> Type[Operation]:
 # Register build-in operations
 for _op_type in [
     # Source
+    send_http_request.SendHttpRequest,
     http_source.HttpSource,
     local_file_source.LocalFileSource,
     s3_object_source.S3ObjectSource,

--- a/src/datarush/core/operations/sources/send_http_request.py
+++ b/src/datarush/core/operations/sources/send_http_request.py
@@ -1,0 +1,82 @@
+"""Send HTTP request operation."""
+
+from typing import Literal
+
+import pandas as pd
+import requests
+from pydantic import Field
+
+from datarush.core.dataflow import Operation, Tableset
+from datarush.core.types import BaseOperationModel, StringMap, TextStr
+
+
+class SendHttpRequestModel(BaseOperationModel):
+    """Model for sending HTTP requests."""
+
+    method: Literal["GET", "POST", "PUT", "DELETE"] = Field(
+        title="Method", description="HTTP method to use"
+    )
+    url: str = Field(title="URL", description="Target URL")
+    headers: StringMap = Field(
+        title="Headers", description="Request headers", default_factory=StringMap
+    )
+    params: StringMap = Field(
+        title="Query Parameters", description="Query parameters", default_factory=StringMap
+    )
+    body: TextStr = Field(
+        title="Request Body",
+        description="Request body (for POST or PUT only)",
+        default=TextStr(""),
+    )
+    response_format: Literal["json", "raw"] = Field(
+        title="Response Format",
+        description="How to parse the response body into a dataframe",
+        default="json",
+    )
+    output_table: str = Field(title="Output Table", description="Table to store response data")
+
+
+class SendHttpRequest(Operation):
+    """Send an HTTP request."""
+
+    name = "send_http_request"
+    title = "Send HTTP Request"
+    description = "Send an HTTP request and parse the response into a table"
+    model: SendHttpRequestModel
+
+    def summary(self) -> str:
+        """Return a summary of the operation."""
+        return (
+            f"Send {self.model.method} request to {self.model.url} "
+            f"and store parsed {self.model.response_format} response in `{self.model.output_table}`"
+        )
+
+    def operate(self, tableset: Tableset) -> Tableset:
+        """Execute the HTTP request and parse the response."""
+        method = self.model.method
+        body = self.model.body if method in ["POST", "PUT"] else None
+
+        response = requests.request(
+            method=method,
+            url=self.model.url,
+            headers=self.model.headers,
+            params=self.model.params,
+            data=body,
+        )
+
+        if self.model.response_format == "raw":
+            df = pd.DataFrame([{"body": response.text}])
+        elif self.model.response_format == "json":
+            try:
+                parsed = response.json()
+                if isinstance(parsed, list):
+                    df = pd.DataFrame(parsed)
+                else:
+                    df = pd.DataFrame([parsed])
+            except Exception as e:
+                raise ValueError(f"Failed to parse JSON: {e}")
+        else:
+            raise ValueError(f"Unsupported response format: {self.model.response_format}")
+
+        tableset.set_df(self.model.output_table, df)
+        return tableset

--- a/src/datarush/core/types.py
+++ b/src/datarush/core/types.py
@@ -86,6 +86,34 @@ class ColumnStr(str):
         )
 
 
+class TextStr(str):
+    """Special string type to mark field that takes multiline text input."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        """Get custom schema for Pydantic validation."""
+        return core_schema.no_info_after_validator_function(
+            lambda v: TextStr(v), core_schema.str_schema()
+        )
+
+
+class StringMap(dict):
+    """Special dict type to mark field that takes dict[str, str] as input."""
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            lambda v: StringMap(v),
+            core_schema.dict_schema(
+                keys_schema=core_schema.str_schema(), values_schema=core_schema.str_schema()
+            ),
+        )
+
+
 @dataclass(frozen=True)
 class ColumnStrMeta:
     """Metadata for ColumnStr type."""

--- a/src/datarush/core/types.py
+++ b/src/datarush/core/types.py
@@ -106,6 +106,7 @@ class StringMap(dict):
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
+        """Get custom schema for Pydantic validation."""
         return core_schema.no_info_after_validator_function(
             lambda v: StringMap(v),
             core_schema.dict_schema(

--- a/src/datarush/ui/form.py
+++ b/src/datarush/ui/form.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from typing import Any, Literal, Type, cast, get_args
 
 import jinja2
+import pandas as pd
 import streamlit as st
 from pydantic import BaseModel, ValidationError
 from pydantic_core import PydanticUndefined
@@ -17,7 +18,9 @@ from datarush.core.types import (
     ColumnStrMeta,
     ContentType,
     RowConditionGroup,
+    StringMap,
     TableStr,
+    TextStr,
     ValueType,
 )
 from datarush.ui.state import get_dataflow
@@ -262,6 +265,31 @@ def model_dict_from_streamlit[T: BaseModel](
                 key=kwargs["key"] + "_condition_group",
                 advanced_mode=advanced_mode,
             )
+        elif field.annotation is TextStr:
+            value = st.text_area(
+                value=current_value if current_value is not None else (default or ""), **kwargs
+            )
+        elif field.annotation is StringMap:
+            st.markdown(
+                f"<div style='font-size:14px; font-weight:400; margin-bottom:6px'>{kwargs['label']}</div>",
+                unsafe_allow_html=True,
+            )
+            value_df = st.data_editor(
+                pd.DataFrame(
+                    data=[(k, v) for k, v in current_value.items()] if current_value else None,
+                    columns=["key", "value"],
+                ),
+                num_rows="dynamic",
+                key=kwargs["key"],
+                use_container_width=True,
+                hide_index=True,
+                column_order=("key", "value"),
+                column_config={
+                    "key": st.column_config.TextColumn("Key", max_chars=100),
+                    "value": st.column_config.TextColumn("Value", max_chars=1000),
+                },
+            )
+            value = dict(zip(value_df["key"], value_df["value"]))
         else:
             raise TypeError(f"Not supported type: {field.annotation}")
 

--- a/src/datarush/ui/form.py
+++ b/src/datarush/ui/form.py
@@ -3,6 +3,7 @@
 # flake8: noqa: D103
 from __future__ import annotations
 
+import json
 from typing import Any, Literal, Type, cast, get_args
 
 import jinja2
@@ -128,7 +129,11 @@ def model_dict_from_streamlit[T: BaseModel](
             # Display the editor for jinja2 template
             st.write(f"{kwargs['label']} template")
             value = st_ace(
-                str(current_value),
+                (
+                    str(current_value)
+                    if not isinstance(current_value, dict)
+                    else json.dumps(current_value)
+                ),
                 language="django",
                 theme="twilight",
                 keybinding="vscode",

--- a/src/datarush/utils/s3_client.py
+++ b/src/datarush/utils/s3_client.py
@@ -28,6 +28,11 @@ class S3Client:
             endpoint_url=config.endpoint,
             aws_access_key_id=config.access_key,
             aws_secret_access_key=config.secret_key.reveal(),
+            aws_session_token=(
+                config.session_token.reveal() if config.session_token else None
+            ),
+            region_name=config.region_name,
+            aws_account_id=config.account_id,
             config=Config(signature_version="s3v4"),
         )
 

--- a/src/datarush/utils/type_utils.py
+++ b/src/datarush/utils/type_utils.py
@@ -22,10 +22,10 @@ def convert_to_type[T](value: str, to_type: type[T] | None) -> T:
     if is_literal(to_type):
         if value not in get_args(to_type):
             raise ValueError(f"Value '{value}' is not a valid literal for type {to_type}")
-        return value
+        return value  # type: ignore
 
-    if issubclass(to_type, BaseModel):
-        return to_type.model_validate_json(value)
+    if to_type is not None and issubclass(to_type, BaseModel):
+        return to_type.model_validate_json(value)  # type: ignore
 
     if to_type not in _TYPE_PARSERS:
         raise ValueError(f"Unsupported type {to_type} for conversion")

--- a/tests/unit/operations/test_send_http_request.py
+++ b/tests/unit/operations/test_send_http_request.py
@@ -1,0 +1,75 @@
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+import responses
+
+from datarush.core.dataflow import Tableset
+from datarush.core.operations.sources.send_http_request import SendHttpRequest
+
+
+@responses.activate
+def test_send_http_request_raw():
+    responses.add(responses.GET, "https://example.com", body="Hello, world!", status=200)
+
+    tableset = Tableset([])
+
+    model = {
+        "method": "GET",
+        "url": "https://example.com",
+        "headers": {},
+        "params": {},
+        "body": "",
+        "output_table": "resp",
+        "response_format": "raw",
+    }
+
+    op = SendHttpRequest(model)
+    result = op.operate(tableset)
+
+    expected = pd.DataFrame([{"body": "Hello, world!"}])
+    pdt.assert_frame_equal(result.get_df("resp"), expected)
+
+
+@responses.activate
+def test_send_http_request_json():
+    responses.add(responses.GET, "https://example.com", json={"foo": "bar"}, status=200)
+
+    tableset = Tableset([])
+
+    model = {
+        "method": "GET",
+        "url": "https://example.com",
+        "headers": {},
+        "params": {},
+        "body": "",
+        "output_table": "resp",
+        "response_format": "json",
+    }
+
+    op = SendHttpRequest(model)
+    result = op.operate(tableset)
+
+    expected = pd.DataFrame([{"foo": "bar"}])
+    pdt.assert_frame_equal(result.get_df("resp"), expected)
+
+
+@responses.activate
+def test_send_http_request_json_parse_error():
+    responses.add(responses.GET, "https://example.com", body="not json", status=200)
+
+    tableset = Tableset([])
+
+    model = {
+        "method": "GET",
+        "url": "https://example.com",
+        "headers": {},
+        "params": {},
+        "body": "",
+        "output_table": "resp",
+        "response_format": "json",
+    }
+
+    op = SendHttpRequest(model)
+
+    with pytest.raises(ValueError, match="Failed to parse JSON"):
+        op.operate(tableset)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ basepython = python3.12
 deps =
     test: coverage
     test: pytest
+    test: responses
     lint: flake8 >= 7.2.0, <8
     lint: flake8-docstrings >= 1.7.0, <2
     lint: pep8-naming >= 0.10.0, <1


### PR DESCRIPTION
New operation model types:
 - `TextStr`
 - `StringMap`
 
 New operations:
 - `SendHttpRequest`
 
 Fixes:
 - Injectable S3 config was not supported for template loading